### PR TITLE
Updates to Azure SSH key references.

### DIFF
--- a/Templates/Azure/Terraform/main.tf
+++ b/Templates/Azure/Terraform/main.tf
@@ -115,7 +115,7 @@ resource "azurerm_linux_virtual_machine" "my_terraform_vm" {
 
   admin_ssh_key {
     username   = var.username
-    public_key = jsondecode(azapi_resource_action.ssh_public_key_gen.output).publicKey
+    public_key = azapi_resource_action.ssh_public_key_gen.output.publicKey
   }
 
   boot_diagnostics {

--- a/Templates/Azure/Terraform/ssh.tf
+++ b/Templates/Azure/Terraform/ssh.tf
@@ -20,5 +20,5 @@ resource "azapi_resource" "ssh_public_key" {
 }
 
 output "key_data" {
-  value = jsondecode(azapi_resource_action.ssh_public_key_gen.output).publicKey
+  value = azapi_resource_action.ssh_public_key_gen.output.publicKey
 }

--- a/documentation/AzureTerraform.md
+++ b/documentation/AzureTerraform.md
@@ -188,7 +188,7 @@ resource "azurerm_linux_virtual_machine" "my_terraform_vm" {
 
   admin_ssh_key {
     username   = var.username
-    public_key = jsondecode(azapi_resource_action.ssh_public_key_gen.output).publicKey
+    public_key = azapi_resource_action.ssh_public_key_gen.output.publicKey
   }
 
   boot_diagnostics {
@@ -258,7 +258,7 @@ resource "azapi_resource" "ssh_public_key" {
 }
 
 output "key_data" {
-  value = jsondecode(azapi_resource_action.ssh_public_key_gen.output).publicKey
+  value = azapi_resource_action.ssh_public_key_gen.output.publicKey
 }
 ```
 


### PR DESCRIPTION
The generated SSH key pair was expected to be in JSON format, but the key pairs are not currently supplied by Terraform in that format.  Perhaps they used to be?  This fix removing the JSON decoding.  Updates have been made both in the `documentation/AzureTerraform.md` file and in the `Templates/Azure/Terraform/ssh.tf` file since the relevant Terraform code appears in both places.

With a properly authenticated Azure CLI client, `terraform init` and `terraform apply` succeed when run in the `Templates/Azure/Terraform` directory.
